### PR TITLE
Feat/returning meta response

### DIFF
--- a/metas_diarias/views.py
+++ b/metas_diarias/views.py
@@ -46,9 +46,12 @@ class MetaConsumoDetalhadaView(APIView):
 
         diario_serializer = MetaConsumoSerializer(meta)
 
-        
+        consumido = 0
+        for consumo in consumo_serializer.data:
+            consumido += consumo["quantidade"]
 
         diario_obj = diario_serializer.data
+        diario_obj["meta_batida"] = consumido >= diario_obj["meta_consumo"]
         diario_obj["consumos"] = consumo_serializer.data
 
         return Response(diario_obj)

--- a/metas_diarias/views.py
+++ b/metas_diarias/views.py
@@ -26,6 +26,7 @@ class MetasConsumoView(APIView):
                 consumido += consumo["quantidade"]
 
             diario["consumiu"] = consumido
+            diario["meta_batida"] = consumido >= diario["meta_consumo"]
 
         
         return Response(diarios)
@@ -44,6 +45,8 @@ class MetaConsumoDetalhadaView(APIView):
         consumo_serializer = ConsumoSerializer(consumos, many=True)
 
         diario_serializer = MetaConsumoSerializer(meta)
+
+        
 
         diario_obj = diario_serializer.data
         diario_obj["consumos"] = consumo_serializer.data


### PR DESCRIPTION
## What?
Foi criado um novo valor no retorno das rotas da API ligadas ao app "metas_diarias". Resolvendo o que é solicitado na issue #3 

## Why?
Conforme dito na issue #3 , as respostas estavam entregando apenas os dados e ainda seria necessária implantação de lógica pelo cliente para que pudessem ser interpretados.

## How?
Com uma verificação sendo executada nas views das rotas, sendo o resultado da soma da **quantidade** de mls dos consumos maior que a **meta_consumo** ele retornará um valor "true", caso não, retornará "false".

## Screenshots:
### Rota de Meta diária com consumos detalhados
![image](https://github.com/robertopnts/Drink-Water-App/assets/83431668/6c788259-9639-488b-9293-bc5aae6b9b91)
### Todos os registros de Metas
![image](https://github.com/robertopnts/Drink-Water-App/assets/83431668/5cb3e235-7bdb-4da6-8f27-0ab3350baa09)

